### PR TITLE
fix: resolve Pip API unreachable (404/405) in production

### DIFF
--- a/apps/pip/.env.production
+++ b/apps/pip/.env.production
@@ -1,0 +1,1 @@
+VITE_API_URL=https://pip-api.azure-api.net/pip-tracker

--- a/apps/pip/public/staticwebapp.config.json
+++ b/apps/pip/public/staticwebapp.config.json
@@ -1,0 +1,6 @@
+{
+  "navigationFallback": {
+    "rewrite": "/index.html",
+    "exclude": ["/api/*", "/*.{png,jpg,gif,css,js,ico,svg,woff,woff2}"]
+  }
+}

--- a/apps/pip/src/hooks/useCaptureManager.ts
+++ b/apps/pip/src/hooks/useCaptureManager.ts
@@ -11,6 +11,7 @@ export interface CaptureItem {
 }
 
 const STORAGE_KEY = 'pip_pending_captures';
+const API_BASE = import.meta.env.VITE_API_URL || '';
 
 export function useCaptureManager() {
   const { getToken } = useAuth();
@@ -20,7 +21,7 @@ export function useCaptureManager() {
   const fetchCaptures = useCallback(async () => {
     try {
       const token = await getToken();
-      const res = await fetch('/api/captures', {
+      const res = await fetch(`${API_BASE}/api/captures`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -56,7 +57,7 @@ export function useCaptureManager() {
 
       try {
         const token = await getToken();
-        const res = await fetch('/api/capture', {
+        const res = await fetch(`${API_BASE}/api/capture`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -89,7 +90,7 @@ export function useCaptureManager() {
 
     const results = await Promise.allSettled(
       pending.map((item: Partial<CaptureItem>) =>
-        fetch('/api/capture', {
+        fetch(`${API_BASE}/api/capture`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',

--- a/apps/pip/src/pages/TrackerPage.tsx
+++ b/apps/pip/src/pages/TrackerPage.tsx
@@ -20,12 +20,13 @@ export function TrackerPage() {
   const { user, login, logout, isAuthenticated, getToken } = useAuth();
   const navigate = useNavigate();
   const [apiResult, setApiResult] = useState<string>("Awaiting input");
+  const API_BASE = import.meta.env.VITE_API_URL || '';
 
   const callApi = async () => {
     try {
         const token = await getToken();
         setApiResult("Calling API...");
-        const res = await fetch("/api/hello", {
+        const res = await fetch(`${API_BASE}/api/hello`, {
             headers: {
                 "Authorization": `Bearer ${token}`
             }


### PR DESCRIPTION
Resolves #28 

### Summary
Fixed the issue where Pip API endpoints were unreachable (404/405) in production by routing requests through the APIM gateway, maintaining the **Free tier** for the Static Web App.

### Changes Made
- **Routing Strategy**: Configured the frontend to use the APIM gateway URL (`https://pip-api.azure-api.net/pip-tracker`) in production via `VITE_API_URL`. This avoids the need for the SWA Standard tier's "Bring your own API" feature.
- **Frontend Updates**: Updated `useCaptureManager` hook and `TrackerPage` to prepended `API_BASE` (from `VITE_API_URL`) to all `/api/*` calls.
- **CORS**: Added `https://pip.finnminn.com` and the SWA default hostname to the `pip-tracker` Function App's allowed origins.
- **Environment**: Added `apps/pip/.env.production`.
- **SWA Config**: Added `apps/pip/public/staticwebapp.config.json` for SPA navigation fallback.

### Verification
- [x] Reverted `Pip-web-app` to Free tier.
- [x] Verified CORS settings on `pip-tracker`.
- [x] Ran `npm run build --filter=pip` to ensure `.env.production` is correctly picked up by Vite and configuration is included in `dist`.

The "Quick Capture" and "Test Spectral Link" features will now communicate with the backend via APIM.