### PR TITLE
fix(pip): correct API base and pathing to resolve 404 in production

### DIFF
--- a/apps/pip/src/hooks/useCaptureManager.ts
+++ b/apps/pip/src/hooks/useCaptureManager.ts
@@ -11,7 +11,7 @@ export interface CaptureItem {
 }
 
 const STORAGE_KEY = 'pip_pending_captures';
-const API_BASE = import.meta.env.VITE_API_URL || '';
+const API_BASE = import.meta.env.VITE_API_URL || '/api';
 
 export function useCaptureManager() {
   const { getToken } = useAuth();
@@ -21,7 +21,7 @@ export function useCaptureManager() {
   const fetchCaptures = useCallback(async () => {
     try {
       const token = await getToken();
-      const res = await fetch(`${API_BASE}/api/captures`, {
+      const res = await fetch(`${API_BASE}/captures`, {
         headers: {
           Authorization: `Bearer ${token}`,
         },
@@ -57,7 +57,7 @@ export function useCaptureManager() {
 
       try {
         const token = await getToken();
-        const res = await fetch(`${API_BASE}/api/capture`, {
+        const res = await fetch(`${API_BASE}/capture`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -90,7 +90,7 @@ export function useCaptureManager() {
 
     const results = await Promise.allSettled(
       pending.map((item: Partial<CaptureItem>) =>
-        fetch(`${API_BASE}/api/capture`, {
+        fetch(`${API_BASE}/capture`, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',


### PR DESCRIPTION
## Description
This PR fixes a 404 error on `pip.finnminn.com` by correcting the API request paths in the frontend.

### Changes
- Updated `API_BASE` in `useCaptureManager.ts` to default to `/api` for local development.
- Removed the hardcoded `/api` prefix from individual `fetch` calls.

This ensures that in production, requests target the correct APIM endpoint (e.g., `https://pip-api.azure-api.net/pip-tracker/captures`) without a double `/api` segment, while local development continues to use the `/api` proxy.

### Verification
- [x] Unit tests passed (`npx turbo run test --filter=pip`).
- [x] Verified local proxy configuration in `vite.config.ts`.
