### PR TITLE
fix(gradle): replace deprecated wrapper-validation with setup-gradle@v4

### DIFF
--- a/.github/workflows/deploy-necrobloom-backend.yml
+++ b/.github/workflows/deploy-necrobloom-backend.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
-          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build and Test with Gradle
         run: ./gradlew clean build azureFunctionsPackage

--- a/.github/workflows/deploy-pip-backend.yml
+++ b/.github/workflows/deploy-pip-backend.yml
@@ -29,15 +29,14 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
-
       - name: Set up JDK ${{ env.JAVA_VERSION }}
         uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: 'temurin'
-          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build and Test with Gradle
         run: ./gradlew clean build azureFunctionsPackage

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -76,6 +76,7 @@ Automated via GitHub Actions with decoupled workflows.
   - `.github/workflows/deploy-necrobloom-backend.yml`
 - **Triggers:** Changes to `apps/pip/api/**` or `apps/necrobloom/api/**`.
 - **Logic:** Builds the Kotlin project using Gradle and deploys to the respective Function App (`pip-tracker`, `necrobloom-api`).
+- **Troubleshooting:** For issues related to Gradle build timeouts or wrapper validation failures, refer to [Gradle Build Issues Guide](docs/guides/GRADLE_BUILD_ISSUES.md).
 
 ## Azure Infrastructure Quick Reference
 - **Subscription ID:** `892ba278-02fb-4119-90b3-83778aacc71f` (Finnminn Production)

--- a/docs/guides/GRADLE_BUILD_ISSUES.md
+++ b/docs/guides/GRADLE_BUILD_ISSUES.md
@@ -1,0 +1,28 @@
+# Gradle Build Issues & Troubleshooting
+
+This guide documents common issues encountered during Gradle builds in CI/CD and local development, and provides solutions to prevent them.
+
+## GitHub Actions: `ETIMEDOUT` during Wrapper Validation
+
+### Problem
+In GitHub Actions workflows, the `gradle/actions/wrapper-validation` action (or deprecated `gradle/wrapper-validation-action`) may fail with the following errors:
+- `Error: Error 0: connect ETIMEDOUT 104.16.73.101:443`
+- `Error: connect ENETUNREACH 2606:4700::6810:4865:443`
+
+### Cause
+This occurs because the validation action attempts to contact `services.gradle.org` (hosted on Cloudflare) to verify the checksum of the `gradle-wrapper.jar`. Since many GitHub Actions runners share the same IP addresses, Cloudflare frequently rate-limits or blocks these IPs, causing the connection to time out.
+
+### Solution
+1. **Use `setup-gradle@v4`**: Always use the official `gradle/actions/setup-gradle@v4` action. It is more robust and handles wrapper validation implicitly.
+2. **Remove Dedicated Validation Steps**: Remove any explicit `gradle/actions/wrapper-validation` steps from your workflows.
+3. **Disable Validation if Persistent**: If the timeout continues even with `setup-gradle@v4`, you can explicitly disable wrapper validation in the action configuration, though this is less secure:
+   ```yaml
+   - name: Setup Gradle
+     uses: gradle/actions/setup-gradle@v4
+     with:
+       validate-wrappers: false
+   ```
+
+## Best Practices
+- **Prefer `setup-gradle` for caching**: Do not use the `cache: 'gradle'` option in `actions/setup-java`. Instead, use `gradle/actions/setup-gradle` which provides a more specialized and reliable caching mechanism for Gradle.
+- **Keep Gradle Wrapper Up-to-Date**: Periodically update the Gradle wrapper to the latest version to benefit from security fixes and performance improvements.


### PR DESCRIPTION
## Description
Fixes the `ETIMEDOUT` error in GitHub Actions caused by Cloudflare rate-limiting GitHub runner IPs during Gradle wrapper validation.

## Changes
- Replaces deprecated `gradle/actions/wrapper-validation` with `gradle/actions/setup-gradle@v4`.
- Updates caching to use the more efficient `setup-gradle` implementation.
- Adds a troubleshooting guide in `docs/guides/GRADLE_BUILD_ISSUES.md`.
- Updates `GEMINI.md` to point to the new troubleshooting guide.